### PR TITLE
Use EntityAINearestAttackableTarget to resolve warnings in Spider Trials

### DIFF
--- a/src/main/java/mustapelto/deepmoblearning/common/entities/EntityTrialCaveSpider.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/entities/EntityTrialCaveSpider.java
@@ -21,7 +21,7 @@ public class EntityTrialCaveSpider extends EntityCaveSpider {
         tasks.addTask(5, new EntityAIWanderAvoidWater(this, 0.8D));
         tasks.addTask(6, new EntityAIWatchClosest(this, EntityPlayer.class, 8.0F));
         tasks.addTask(6, new EntityAILookIdle(this));
-        targetTasks.addTask(0, new EntityAIFindEntityNearestPlayer(this));
+        targetTasks.addTask(0, new EntityAINearestAttackableTarget<>(this, EntityPlayer.class, false));
     }
 
     static class AISpiderAttack extends EntityAIAttackMelee {

--- a/src/main/java/mustapelto/deepmoblearning/common/entities/EntityTrialSpider.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/entities/EntityTrialSpider.java
@@ -20,7 +20,7 @@ public class EntityTrialSpider extends EntitySpider {
         tasks.addTask(5, new EntityAIWanderAvoidWater(this, 0.8D));
         tasks.addTask(6, new EntityAIWatchClosest(this, EntityPlayer.class, 8.0F));
         tasks.addTask(6, new EntityAILookIdle(this));
-        targetTasks.addTask(0, new EntityAIFindEntityNearestPlayer(this));
+        targetTasks.addTask(0, new EntityAINearestAttackableTarget<>(this, EntityPlayer.class, false));
     }
 
     static class AISpiderAttack extends EntityAIAttackMelee {


### PR DESCRIPTION
Fixes the following warning:
[Server thread/WARN] [minecraft/EntityAIFindEntityNearestPlayer]: Use NearestAttackableTargetGoal.class for PathfinerMob mobs!
by simply using EntityAINearestAttackableTarget.