### PR TITLE
Check side for LivingDeathEvent

### DIFF
--- a/src/main/java/mustapelto/deepmoblearning/common/events/EntityDeathEventHandler.java
+++ b/src/main/java/mustapelto/deepmoblearning/common/events/EntityDeathEventHandler.java
@@ -61,6 +61,9 @@ public class EntityDeathEventHandler {
 
     @SubscribeEvent
     public static void entityDeath(LivingDeathEvent event) {
+        if (event.getEntityLiving().world.isRemote) {
+            return;
+        }
         if (event.getEntityLiving() instanceof EntityPlayer) {
             handlePlayerDeath((EntityPlayer) event.getEntityLiving());
         } else {


### PR DESCRIPTION
`killedEntityUUIDBlacklist` in `EntityDeathEventHandler` is not a thread-safe list, and `entityDeath(LivingDeathEvent)` was firing twice, from the client and server. This would cause undefined behavior with crashes that looked like [this](https://mclo.gs/gVyFhXw) and [this](https://mclo.gs/MPfmSPh). It looks like the code should only be run server side, so added a check.