### PR TITLE
Fix GUIs Interaction with JEI Bookmarks

### DIFF
--- a/src/main/java/mustapelto/deepmoblearning/client/gui/GuiMachine.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/gui/GuiMachine.java
@@ -10,6 +10,10 @@ import mustapelto.deepmoblearning.common.util.Rect;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.world.World;
 
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+
 public abstract class GuiMachine extends GuiContainerTickable {
 
     protected final TileEntityMachine tileEntity;
@@ -70,5 +74,19 @@ public abstract class GuiMachine extends GuiContainerTickable {
                 energyBar.WIDTH,
                 energyBarHeight
         );
+    }
+
+    /**
+     * Used for JEI Compat. By default, returns the rectangle covering the redstone button area.
+     */
+    public List<Rectangle> getGuiExclusionAreas() {
+        List<Rectangle> result = new ArrayList<>();
+        result.add(new Rectangle(
+                redstoneModeButton.x,
+                redstoneModeButton.y,
+                redstoneModeButton.width,
+                redstoneModeButton.height
+        ));
+        return result;
     }
 }

--- a/src/main/java/mustapelto/deepmoblearning/client/gui/GuiSimulationChamber.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/gui/GuiSimulationChamber.java
@@ -16,6 +16,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.text.TextFormatting;
 import net.minecraft.world.World;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -275,6 +276,18 @@ public class GuiSimulationChamber extends GuiMachine {
 
         drawInfoboxText(deltaTime, guiLeft + INFO_BOX.X, guiTop + INFO_BOX.Y);
         drawConsoleText(deltaTime, guiLeft + CONSOLE.X, guiTop + CONSOLE.Y);
+    }
+
+    @Override
+    public List<Rectangle> getGuiExclusionAreas() {
+        List<Rectangle> result =  super.getGuiExclusionAreas();
+        result.add(new Rectangle(
+                guiLeft + DATA_MODEL_SLOT.LEFT,
+                guiTop + DATA_MODEL_SLOT.TOP,
+                DATA_MODEL_SLOT.WIDTH,
+                DATA_MODEL_SLOT.HEIGHT
+        ));
+        return result;
     }
 
     private void drawInfoboxText(float advanceAmount, int left, int top) {

--- a/src/main/java/mustapelto/deepmoblearning/client/gui/GuiTrialKeystone.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/gui/GuiTrialKeystone.java
@@ -20,6 +20,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -327,6 +328,17 @@ public class GuiTrialKeystone extends GuiContainerTickable {
                 guiLeft + TRIAL_INFO_TEXT_RIGHT.X,
                 guiTop + TRIAL_INFO_TEXT_RIGHT.Y + (int)(2.5 * ROW_SPACING),
                 Colors.AQUA
+        );
+    }
+    
+    public List<Rectangle> getGuiExclusionAreas() {
+        return ImmutableList.of(
+                new Rectangle(
+                        guiLeft + TRIAL_KEY_SLOT.LEFT,
+                        guiTop + TRIAL_KEY_SLOT.TOP,
+                        TRIAL_KEY_SLOT.WIDTH,
+                        TRIAL_KEY_SLOT.HEIGHT
+                )
         );
     }
 }

--- a/src/main/java/mustapelto/deepmoblearning/client/jei/DMLJeiPlugin.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/jei/DMLJeiPlugin.java
@@ -1,6 +1,5 @@
 package mustapelto.deepmoblearning.client.jei;
 
-import com.google.common.collect.ImmutableList;
 import mezz.jei.api.IGuiHelper;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
@@ -47,6 +46,11 @@ public class DMLJeiPlugin implements IModPlugin {
 
     @Override
     public void register(@Nonnull IModRegistry registry) {
+
+        // Gui Handlers
+        registry.addAdvancedGuiHandlers(
+                new GuiExclusionHandlers.MachineGuiExclusion(),
+                new GuiExclusionHandlers.TrialGuiExclusion());
 
         // Simulation Chamber
         registry.handleRecipes(SimulationChamberRecipe.class, SimulationChamberWrapper::new, simChamberCategory.getUid());

--- a/src/main/java/mustapelto/deepmoblearning/client/jei/GuiExclusionHandlers.java
+++ b/src/main/java/mustapelto/deepmoblearning/client/jei/GuiExclusionHandlers.java
@@ -1,0 +1,37 @@
+package mustapelto.deepmoblearning.client.jei;
+
+import mezz.jei.api.gui.IAdvancedGuiHandler;
+import mustapelto.deepmoblearning.client.gui.GuiMachine;
+import mustapelto.deepmoblearning.client.gui.GuiTrialKeystone;
+import org.jetbrains.annotations.Nullable;
+
+import java.awt.*;
+import java.util.List;
+
+public class GuiExclusionHandlers {
+    public static class MachineGuiExclusion implements IAdvancedGuiHandler<GuiMachine> {
+
+        @Override
+        public Class<GuiMachine> getGuiContainerClass() {
+            return GuiMachine.class;
+        }
+
+        @Override
+        public @Nullable List<Rectangle> getGuiExtraAreas(GuiMachine guiContainer) {
+            return guiContainer.getGuiExclusionAreas();
+        }
+    }
+
+    public static class TrialGuiExclusion implements IAdvancedGuiHandler<GuiTrialKeystone> {
+
+        @Override
+        public Class<GuiTrialKeystone> getGuiContainerClass() {
+            return GuiTrialKeystone.class;
+        }
+
+        @Override
+        public @Nullable List<Rectangle> getGuiExtraAreas(GuiTrialKeystone guiContainer) {
+            return guiContainer.getGuiExclusionAreas();
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes DME's machines' GUIs overlapping with JEI's bookmark bar.

Note: when cheat mode is enabled, with the previous implementation, sometimes, adding items into the key or model slots would delete it instead.

## Old Behaviour:
<img width="1512" alt="Screenshot 2024-11-24 at 8 40 30 pm" src="https://github.com/user-attachments/assets/c3c86ccf-fb9e-485a-baea-1f2f1a6f6141">
<img width="1512" alt="Screenshot 2024-11-24 at 8 39 42 pm" src="https://github.com/user-attachments/assets/5014e105-b29d-4d9e-a937-19cf5b91e6a8">
<img width="1512" alt="Screenshot 2024-11-24 at 8 39 59 pm" src="https://github.com/user-attachments/assets/362ae976-3aff-4c04-8e61-664caec4842f">

## New Behaviour:
<img width="1512" alt="Screenshot 2024-11-24 at 9 03 12 pm" src="https://github.com/user-attachments/assets/38b2431e-6849-4432-9a7d-536cfd82409d">
<img width="1512" alt="Screenshot 2024-11-24 at 9 03 02 pm" src="https://github.com/user-attachments/assets/ec4bbc57-fcec-42ef-b0c1-ba98640b406a">
<img width="1512" alt="Screenshot 2024-11-24 at 9 02 55 pm" src="https://github.com/user-attachments/assets/71c239db-9045-4254-9233-5cea68db6375">